### PR TITLE
Add safe area insets

### DIFF
--- a/insetsx/src/androidMain/kotlin/com/moriatsushi/insetsx/WindowInsets.android.kt
+++ b/insetsx/src/androidMain/kotlin/com/moriatsushi/insetsx/WindowInsets.android.kt
@@ -1,11 +1,13 @@
 package com.moriatsushi.insetsx
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout as androidDisplayCutout
 import androidx.compose.foundation.layout.ime as androidIme
 import androidx.compose.foundation.layout.navigationBars as androidNavigationBars
 import androidx.compose.foundation.layout.safeDrawing as androidSafeDrawing
 import androidx.compose.foundation.layout.statusBars as androidStatusBars
 import androidx.compose.foundation.layout.systemBars as androidSystemBars
+import androidx.compose.foundation.layout.union
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
 
@@ -23,6 +25,14 @@ actual val WindowInsets.Companion.systemBars: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = androidSystemBars
+
+/**
+ * The insets that include unsafe areas such as system bars and display cutouts.
+ */
+actual val WindowInsets.Companion.safeArea: WindowInsets
+    @Composable
+    @NonRestartableComposable
+    get() = androidSystemBars.union(androidDisplayCutout)
 
 actual val WindowInsets.Companion.ime: WindowInsets
     @Composable

--- a/insetsx/src/androidMain/kotlin/com/moriatsushi/insetsx/WindowInsets.android.kt
+++ b/insetsx/src/androidMain/kotlin/com/moriatsushi/insetsx/WindowInsets.android.kt
@@ -11,34 +11,50 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
 
+/**
+ * The insets representing navigation bars.
+ */
 actual val WindowInsets.Companion.navigationBars: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = androidNavigationBars
 
+/**
+ * The insets representing status bars.
+ */
 actual val WindowInsets.Companion.statusBars: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = androidStatusBars
 
+/**
+ * The insets representing system bars, but not including ime.
+ */
 actual val WindowInsets.Companion.systemBars: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = androidSystemBars
 
 /**
- * The insets that include unsafe areas such as system bars and display cutouts.
+ * The insets that include unsafe areas such as system bars and display cutouts,
+ * but not including ime.
  */
 actual val WindowInsets.Companion.safeArea: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = androidSystemBars.union(androidDisplayCutout)
 
+/**
+ * The insets representing the area of the software keyboard.
+ */
 actual val WindowInsets.Companion.ime: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = androidIme
 
+/**
+ * The insets that include areas where content may be covered by other drawn content.
+ */
 actual val WindowInsets.Companion.safeDrawing: WindowInsets
     @Composable
     @NonRestartableComposable

--- a/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsets.kt
+++ b/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsets.kt
@@ -3,12 +3,30 @@ package com.moriatsushi.insetsx
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 
+/**
+ * The insets representing navigation bars.
+ *
+ * * In Android: navigation bars
+ * * In iOS: bottom of safe area (home indicator)
+ */
 expect val WindowInsets.Companion.navigationBars: WindowInsets
     @Composable get
 
+/**
+ * The insets representing status bars.
+ *
+ * * In Android: status bars
+ * * In iOS: top of safe area (status bar)
+ */
 expect val WindowInsets.Companion.statusBars: WindowInsets
     @Composable get
 
+/**
+ * The insets representing system bars, but not including ime.
+ *
+ * * In Android: navigation bars + status bars + caption bars
+ * * In iOS: top and bottom of safe area (home indicator + status bar)
+ */
 expect val WindowInsets.Companion.systemBars: WindowInsets
     @Composable get
 
@@ -22,10 +40,22 @@ expect val WindowInsets.Companion.systemBars: WindowInsets
 expect val WindowInsets.Companion.safeArea: WindowInsets
     @Composable get
 
+/**
+ * The insets representing the area of the software keyboard.
+ *
+ * * In Android: IME
+ * * In iOS: IME
+ */
 @ExperimentalSoftwareKeyboardApi
 expect val WindowInsets.Companion.ime: WindowInsets
     @Composable get
 
+/**
+ * The insets that include areas where content may be covered by other drawn content.
+ *
+ * * In Android: system bars + display cutouts + IME
+ * * In iOS: safe area + IME
+ */
 @ExperimentalSoftwareKeyboardApi
 expect val WindowInsets.Companion.safeDrawing: WindowInsets
     @Composable get

--- a/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsets.kt
+++ b/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsets.kt
@@ -12,6 +12,16 @@ expect val WindowInsets.Companion.statusBars: WindowInsets
 expect val WindowInsets.Companion.systemBars: WindowInsets
     @Composable get
 
+/**
+ * The insets that include unsafe areas such as system bars and display cutouts,
+ * but not including ime.
+ *
+ * * In Android: system bars + display cutouts (not including IME)
+ * * In iOS: safe area (not including IME)
+ */
+expect val WindowInsets.Companion.safeArea: WindowInsets
+    @Composable get
+
 @ExperimentalSoftwareKeyboardApi
 expect val WindowInsets.Companion.ime: WindowInsets
     @Composable get

--- a/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsetsPadding.kt
+++ b/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsetsPadding.kt
@@ -11,6 +11,13 @@ fun Modifier.safeDrawingPadding() = Modifier.windowInsetsPadding {
     WindowInsets.safeDrawing
 }
 
+/**
+ * Adds padding to accommodate the [safe area][WindowInsets.Companion.safeArea] insets.
+ */
+fun Modifier.safeAreaPadding() = Modifier.windowInsetsPadding {
+    WindowInsets.safeArea
+}
+
 fun Modifier.systemBarsPadding() = Modifier.windowInsetsPadding {
     WindowInsets.systemBars
 }

--- a/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsetsPadding.kt
+++ b/insetsx/src/commonMain/kotlin/com/moriatsushi/insetsx/WindowInsetsPadding.kt
@@ -6,6 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 
+/**
+ * Adds padding to accommodate the [safe drawing][WindowInsets.Companion.safeDrawing] insets.
+ */
 @ExperimentalSoftwareKeyboardApi
 fun Modifier.safeDrawingPadding() = Modifier.windowInsetsPadding {
     WindowInsets.safeDrawing
@@ -18,19 +21,31 @@ fun Modifier.safeAreaPadding() = Modifier.windowInsetsPadding {
     WindowInsets.safeArea
 }
 
+/**
+ * Adds padding to accommodate the [system bars][WindowInsets.Companion.systemBars] insets.
+ */
 fun Modifier.systemBarsPadding() = Modifier.windowInsetsPadding {
     WindowInsets.systemBars
 }
 
+/**
+ * Adds padding to accommodate the [status bars][WindowInsets.Companion.statusBars] insets.
+ */
 fun Modifier.statusBarsPadding() = Modifier.windowInsetsPadding {
     WindowInsets.statusBars
 }
 
+/**
+ * Adds padding to accommodate the [ime][WindowInsets.Companion.ime] insets.
+ */
 @ExperimentalSoftwareKeyboardApi
 fun Modifier.imePadding() = Modifier.windowInsetsPadding {
     WindowInsets.ime
 }
 
+/**
+ * Adds padding to accommodate the [navigation bars][WindowInsets.Companion.navigationBars] insets.
+ */
 fun Modifier.navigationBarsPadding() = Modifier.windowInsetsPadding {
     WindowInsets.navigationBars
 }

--- a/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsets.uikit.kt
+++ b/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsets.uikit.kt
@@ -19,6 +19,15 @@ actual val WindowInsets.Companion.systemBars: WindowInsets
     @NonRestartableComposable
     get() = WindowInsetsHolder.current().systemBars
 
+/**
+ * The insets representing the safe area.
+ */
+@ExperimentalSoftwareKeyboardApi
+actual val WindowInsets.Companion.safeArea: WindowInsets
+    @Composable
+    @NonRestartableComposable
+    get() = WindowInsetsHolder.current().safeArea
+
 @ExperimentalSoftwareKeyboardApi
 actual val WindowInsets.Companion.ime: WindowInsets
     @Composable

--- a/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsets.uikit.kt
+++ b/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsets.uikit.kt
@@ -4,16 +4,25 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
 
+/**
+ * The insets representing the home indicator.
+ */
 actual val WindowInsets.Companion.navigationBars: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = WindowInsetsHolder.current().navigationBars
 
+/**
+ * The insets representing the status bar.
+ */
 actual val WindowInsets.Companion.statusBars: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = WindowInsetsHolder.current().statusBars
 
+/**
+ * The insets representing system bars, but not including ime.
+ */
 actual val WindowInsets.Companion.systemBars: WindowInsets
     @Composable
     @NonRestartableComposable
@@ -28,12 +37,18 @@ actual val WindowInsets.Companion.safeArea: WindowInsets
     @NonRestartableComposable
     get() = WindowInsetsHolder.current().safeArea
 
+/**
+ * The insets representing the area of the software keyboard.
+ */
 @ExperimentalSoftwareKeyboardApi
 actual val WindowInsets.Companion.ime: WindowInsets
     @Composable
     @NonRestartableComposable
     get() = WindowInsetsHolder.current().ime
 
+/**
+ * The insets that include areas where content may be covered by other drawn content.
+ */
 @ExperimentalSoftwareKeyboardApi
 actual val WindowInsets.Companion.safeDrawing: WindowInsets
     @Composable

--- a/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsetsHolder.uikit.kt
+++ b/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsetsHolder.uikit.kt
@@ -33,11 +33,12 @@ import platform.darwin.NSObject
 internal class WindowInsetsHolder(
     private val coroutineContext: CoroutineContext,
 ) {
-    val systemBars = UIKitSafeAreaInsets()
-    val navigationBars = systemBars.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
-    val statusBars = systemBars.only(WindowInsetsSides.Top)
+    private val safeArea = UIKitSafeAreaInsets()
+    val navigationBars = safeArea.only(WindowInsetsSides.Bottom)
+    val statusBars = safeArea.only(WindowInsetsSides.Top)
+    val systemBars = navigationBars.union(statusBars)
     val ime = UIKeyboardInsets()
-    val safeDrawing = systemBars.union(ime)
+    val safeDrawing = safeArea.union(ime)
 
     private val coroutineJob = Job()
     private val coroutineScope = CoroutineScope(coroutineContext + Job())
@@ -76,7 +77,7 @@ internal class WindowInsetsHolder(
         @Suppress("unused")
         @ObjCAction
         override fun safeAreaInsetsDidChange() {
-            systemBars.update(this)
+            safeArea.update(this)
         }
     }
 
@@ -84,7 +85,7 @@ internal class WindowInsetsHolder(
         accessCount++
         if (accessCount == 1) {
             viewController.view.insertSubview(insetsListenerView, 0)
-            systemBars.update(insetsListenerView)
+            safeArea.update(insetsListenerView)
             NSNotificationCenter.defaultCenter.addObserver(
                 observer = keyboardVisibilityListener,
                 selector = NSSelectorFromString("keyboardWillShow:"),

--- a/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsetsHolder.uikit.kt
+++ b/insetsx/src/uikitMain/kotlin/com/moriatsushi/insetsx/WindowInsetsHolder.uikit.kt
@@ -33,7 +33,7 @@ import platform.darwin.NSObject
 internal class WindowInsetsHolder(
     private val coroutineContext: CoroutineContext,
 ) {
-    private val safeArea = UIKitSafeAreaInsets()
+    val safeArea = UIKitSafeAreaInsets()
     val navigationBars = safeArea.only(WindowInsetsSides.Bottom)
     val statusBars = safeArea.only(WindowInsetsSides.Top)
     val systemBars = navigationBars.union(statusBars)


### PR DESCRIPTION
Add WindowInsets.safeArea to more accurately represent iOS safe areas.
Change some iOS navigationBars insets and systemBars insets to match Android behavior.